### PR TITLE
Connect worker endpoint and filter by views

### DIFF
--- a/proxy/worker.js
+++ b/proxy/worker.js
@@ -12,7 +12,11 @@ async function handleRequest(request) {
   apiUrl.search = url.search;
 
   const olxResp = await fetch(apiUrl.toString(), {
-    headers: { 'Accept-Language': request.headers.get('accept-language') || 'en-US' }
+    headers: {
+      'Accept-Language': request.headers.get('accept-language') || 'uk',
+      'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64)',
+      'Referer': 'https://www.olx.ua/'
+    }
   });
 
   const headers = new Headers(olxResp.headers);

--- a/public/app.js
+++ b/public/app.js
@@ -46,11 +46,12 @@ fetch(CATEGORIES_URL)
    if (form.category.value) params.append('category_id', form.category.value);
   try {
     const resp = await fetch(PROXY_URL + '?' + params.toString(), {
-      headers: { 'Accept-Language': form.lang.value }
+      headers: { 'Accept-Language': form.lang.value || 'uk' }
     });
     const data = await resp.json();
     const tbody = $('#results tbody').empty();
-    (data.data || []).forEach(offer => {
+    const offers = (data.data || []).filter(offer => offer.stats?.views > 2000);
+    offers.forEach(offer => {
       const title = offer.title || '—';
       const price = (offer.price && offer.price.value) || '—';
       const city = (offer.location && offer.location.city) || '—';


### PR DESCRIPTION
## Summary
- add Accept-Language default and filter offers with more than 2000 views
- send additional headers from the Cloudflare worker

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_683c90cd36f883208cbc5fa7e989c5d4