### PR TITLE
Proxy categories via worker

### DIFF
--- a/proxy/worker.js
+++ b/proxy/worker.js
@@ -4,12 +4,15 @@ addEventListener('fetch', event => {
 
 async function handleRequest(request) {
   const url = new URL(request.url);
-  if (url.pathname !== '/offers') {
+  let apiUrl;
+  if (url.pathname === '/offers') {
+    apiUrl = new URL('https://www.olx.ua/api/v1/offers');
+    apiUrl.search = url.search;
+  } else if (url.pathname === '/offers/categories') {
+    apiUrl = new URL('https://www.olx.ua/api/v1/offers/categories');
+  } else {
     return new Response('Not found', { status: 404 });
   }
-
-  const apiUrl = new URL('https://www.olx.ua/api/v1/offers');
-  apiUrl.search = url.search;
 
   const olxResp = await fetch(apiUrl.toString(), {
     headers: {

--- a/public/app.js
+++ b/public/app.js
@@ -1,8 +1,8 @@
 // URL вашего прокси. Значение берётся из window.PROXY_URL (см. index.html)
 const PROXY_URL = window.PROXY_URL || 'https://your-proxy.example.com/offers';
 
-// load categories and init jstree
-const CATEGORIES_URL = 'https://www.olx.ua/api/v1/partner/categories';
+// load categories and init jstree through the proxy to avoid CORS
+const CATEGORIES_URL = PROXY_URL + '/categories';
 fetch(CATEGORIES_URL)
   .then(res => res.json())
   .then(data => {
@@ -19,7 +19,9 @@ fetch(CATEGORIES_URL)
         return node;
       });
 
-    const categories = data.data || data.categories || [];
+    // the API may return categories in different fields
+    const categories =
+      (data.data && data.data.categories) || data.categories || data.data || [];
     const treeData = buildTree(categories);
     $('#category-tree').jstree({
       core: { data: treeData }


### PR DESCRIPTION
## Summary
- load categories via the proxy
- support category requests in worker

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_b_683c924c33d083209d5c663c3dc42dac