### PR TITLE
Add CORS header for 404 responses

### DIFF
--- a/proxy/worker.js
+++ b/proxy/worker.js
@@ -12,7 +12,10 @@ async function handleRequest(request) {
   } else if (url.pathname === '/offers/categories' || url.pathname === '/categories') {
     endpoint = 'https://www.olx.ua/api/v1/offers/categories';
   } else {
-    return new Response('Not found', { status: 404 });
+    return new Response('Not found', {
+      status: 404,
+      headers: { 'Access-Control-Allow-Origin': '*' }
+    });
   }
 
   const apiUrl = new URL(endpoint);


### PR DESCRIPTION
## Summary
- include `Access-Control-Allow-Origin: *` on 404 responses in the worker

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_683cade36b7483209c47494337bfc94c