### PR TITLE
Fix categories parsing

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -41,8 +41,13 @@ fetch(CATEGORIES_URL)
       });
 
     // API может возвращать категории в разных полях
-    const categories =
-      (data.data && data.data.categories) || data.categories || data.data || [];
+    const categories = Array.isArray(data.data?.categories)
+      ? data.data.categories
+      : Array.isArray(data.categories)
+      ? data.categories
+      : Array.isArray(data.data)
+      ? data.data
+      : [];
     const treeData = buildTree(categories);
     $('#category-tree')
       .jstree({


### PR DESCRIPTION
## Summary
- ensure categories parsing always returns an array

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_b_683cb06052d08320a0b415dc4271a4a7