### PR TITLE
Fix secure links

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -106,7 +106,13 @@ document.getElementById('parserForm').addEventListener('submit', async e => {
       $('<td>').text(price).appendTo(tr);
       $('<td>').text(city).appendTo(tr);
       $('<td>')
-        .append($('<a>').attr('href', url).attr('target', '_blank').text('Ссылка'))
+        .append(
+          $('<a>')
+            .attr('href', url)
+            .attr('target', '_blank')
+            .attr('rel', 'noopener noreferrer')
+            .text('Ссылка')
+        )
         .appendTo(tr);
       tbody.append(tr);
     });


### PR DESCRIPTION
## Summary
- open offer links in a new tab with `rel="noopener noreferrer"`

No tests are provided in this repository.

------
https://chatgpt.com/codex/tasks/task_b_683cba4e152083208969ddf048e5fb19